### PR TITLE
Add difficulty button in sync with level chosen

### DIFF
--- a/components/Sheet/Sheet.tsx
+++ b/components/Sheet/Sheet.tsx
@@ -5,6 +5,7 @@ import { Checkbox } from "@/components/ui/Checkbox";
 import { useState, useEffect } from "react";
 import SkeletonLoader from "./Loading";
 import { Suspense } from "react";
+import {clsx} from 'clsx';
 
 export default function Sheet() {
   const [difficulty, setDifficulty] = useState("easy");
@@ -37,17 +38,16 @@ export default function Sheet() {
       <div className="flex flex-col justify-center gap-20 ">
         <div className="mx-auto mt-20 min-h-screen max-w-7xl">
           <div className="flex flex-1 flex-row text-xs">
-            <button
-              className="rounded-tl rounded-bl border px-2 py-2 tracking-wider text-white  border-slate-700"
+          <button
+              className={clsx("rounded-tl rounded-bl border px-2 py-2 tracking-wider text-white  border-slate-700", {"border-[#06b6d4]" : difficulty=="easy"})}
               onClick={() => {
                 setDifficulty("easy");
               }}
-              style={{ borderColor: "#06b6d4" }}
             >
               Easy
             </button>
             <button
-              className="border px-2 py-2 tracking-wider text-white border-slate-700"
+              className={clsx("border px-2 py-2 tracking-wider text-white border-slate-700", {"border-[#06b6d4]" : difficulty=="medium"})}
               onClick={() => {
                 setDifficulty("medium");
               }}
@@ -55,7 +55,7 @@ export default function Sheet() {
               Medium
             </button>
             <button
-              className="rounded-tr rounded-br border px-2 py-2 tracking-wider text-white border-slate-700"
+              className={clsx("rounded-tr rounded-br border px-2 py-2 tracking-wider text-white border-slate-700", {"border-[#06b6d4]" : difficulty=="hard"})}
               onClick={() => {
                 setDifficulty("hard");
               }}


### PR DESCRIPTION
In DSA sheet tab, the difficulty buttons changes it border color according to level chosen by user (by default it is easy)

<img  width="236" alt="Screenshot 2024-05-14 at 8 45 17 PM" src="https://github.com/animeshchaudhri/dsaatlas/assets/109858950/02978951-eee7-4466-b0ba-4df4e39caf4d">
